### PR TITLE
Amend logging statements to use deferred interpolation

### DIFF
--- a/pyfldigi/client/client.py
+++ b/pyfldigi/client/client.py
@@ -67,7 +67,7 @@ class Client(object):
         self.logger = logging.getLogger('pyfldigi.Client')
         self.ip_address = hostname
         self.port = port
-        self.logger.debug('Attempting to connect to connect to fldigi at IP address={}, port={}, via XMP-RPC'.format(self.ip_address, self.port))
+        self.logger.debug('Attempting to connect to connect to fldigi at IP address=%r, port=%d, via XMP-RPC', self.ip_address, self.port)
         self.client = xmlrpc.client.ServerProxy('http://{}:{}/'.format(self.ip_address, self.port), transport=RequestsTransport(use_builtin_types=True), allow_none=True)
         self.main = Main(clientObj=self)
         self.modem = Modem(clientObj=self)
@@ -127,7 +127,7 @@ class Client(object):
         fldigi
         '''
         name = self.client.fldigi.name()
-        self.logger.debug('name returned {}'.format(name))
+        self.logger.debug('name returned %r', name)
 
     @property
     def version(self):

--- a/pyfldigi/client/main.py
+++ b/pyfldigi/client/main.py
@@ -397,7 +397,7 @@ class Main(object):
         >>> c.main.send('Lorem ipsum dolor sit amet', timeout=50)
         '''
         state = self.clientObj.main.get_trx_state()
-        self.logger.debug('send(): state={}'.format(state))
+        self.logger.debug('send(): state=%r', state)
 
         if state == 'TX':  # already chooching
             tx_start = time.time()

--- a/pyfldigi/client/text.py
+++ b/pyfldigi/client/text.py
@@ -18,11 +18,10 @@ class Text(object):
         :param value: The data to be sent to FLDIGI's TX text widget
         :type value: bytes or str
         '''
+        self.logger.debug('add_tx(%r)', value)
         if isinstance(value, bytes):
-            self.logger.debug('add_tx({})'.format(value))
             self.client.text.add_tx_bytes(value)
         elif isinstance(value, str):
-            self.logger.debug('add_tx(\'{}\')'.format(value))
             self.client.text.add_tx(value)
         else:
             raise TypeError('text must be in bytes or str format')
@@ -51,7 +50,7 @@ class Text(object):
             else:
                 raise e
         else:
-            self.logger.debug('get_tx_data() returned: {}'.format(data))
+            self.logger.debug('get_tx_data() returned: %r', data)
             return data
 
     def get_rx_data(self):
@@ -61,7 +60,7 @@ class Text(object):
         :rtype: str
         '''
         data = self.client.rx.get_data()
-        self.logger.debug('get_rx_data() returned: {}'.format(data))
+        self.logger.debug('get_rx_data() returned: %r', data)
         return data
 
     def clear_rx(self):

--- a/pyfldigi/client/txmonitor.py
+++ b/pyfldigi/client/txmonitor.py
@@ -106,7 +106,7 @@ class _History(object):
             raise TypeError('expected state type to be _State but got {}'.format(type(new_state)))
         last_state = self.state_history[-1].state
         if new_state.state != last_state:
-            self.logger.info('STATE CHANGE to {}'.format(new_state.state))
+            self.logger.info('STATE CHANGE to %r', new_state.state)
             self.state_history[-1].end()
             self.state_history.append(new_state)
             self.chop()
@@ -175,7 +175,7 @@ class TxMonitor(threading.Thread):
                 data = self.clientObj.text.get_tx_data(suppress_errors=True)
                 if data is not None:
                     if len(data) > 0:
-                        self.logger.debug('TXMONITOR: TX DATA: {}'.format(data))
+                        self.logger.debug('TXMONITOR: TX DATA: %r', data)
                         self.history.append_txdata(_TxData(data))
 
                 if state == 'TX':
@@ -192,7 +192,7 @@ class TxMonitor(threading.Thread):
                             self.clientObj.main.rx()  # put the state back into receive
                             self.transmitting = False
                             # print('txdata_time = {}'.format(t))
-                            self.logger.info('Changing state back to RX... (last transmitted byte was {} seconds ago'.format(t))
+                            self.logger.info('Changing state back to RX... (last transmitted byte was %d seconds ago', t)
                 elif state == 'ERROR':
                     break
                 else:

--- a/pyfldigi/xmlconfig.py
+++ b/pyfldigi/xmlconfig.py
@@ -222,7 +222,7 @@ class XmlMonitor(object):
         self.logger.addHandler(self.fh)
         self.logger.addHandler(self.sh)
 
-        self.logger.info('Monitoring {}...'.format(self.location))
+        self.logger.info('Monitoring %s...', self.location)
 
         # Setup the thread
         self._timer = None
@@ -257,7 +257,7 @@ class XmlMonitor(object):
             for key, value in old.items():
                 try:
                     if new[key] != value:
-                        self.logger.info('{} changed from {} to {}'.format(key.upper(), value, new[key]))
+                        self.logger.info('%s changed from %r to %r', key.upper(), value, new[key])
                 except KeyError:
                     pass  # TBD
             self.settings = new


### PR DESCRIPTION
Skipping .format() avoids formatting the message if the log level would
not otherwise emit the message.