### PR TITLE
Add darwin to list of allowed OSes

### DIFF
--- a/pyfldigi/appmonitor.py
+++ b/pyfldigi/appmonitor.py
@@ -27,7 +27,7 @@ class ApplicationMonitor(object):
         self.platform = sys.platform
         self.hostname = hostname
         self.port = int(port)
-        if self.platform not in ['linux', 'win32']:
+        if self.platform not in ['linux', 'win32', 'darwin']:
             raise Exception('You\'re probably using an OS that is unsupported.  Sorry about that.  I take pull requests.')
         self.client = xmlrpc.client.ServerProxy('http://{}:{}/'.format(self.hostname, self.port))
         self.process = None


### PR DESCRIPTION
I have been using this on MacOS 10.15.4 ('darwin') and have not experienced any platform-specific issues.