### PR TITLE
Sleep During Polling Loops To Reduce High CPU Usage

### DIFF
--- a/pyfldigi/client/main.py
+++ b/pyfldigi/client/main.py
@@ -293,7 +293,7 @@ class Main(object):
                     state = 'ERROR'
             if state in ['TX', 'RX', 'TUNE']:
                 break
-            time.sleep(0.005)
+            time.sleep(0.05)
         else:
             state = 'ERROR'
         return state
@@ -417,6 +417,7 @@ class Main(object):
                     break
                 if time.time() - tx_start >= timeout:
                     raise TimeoutError('Timeout while transmitting, waiting for first byte to go out')
+                time.sleep(0.05)
         else:
             raise Exception('cannot transmit if FLDIGI state is {!r}'.format(state))
 
@@ -427,3 +428,4 @@ class Main(object):
                     break
                 if time.time() - tx_start >= timeout:
                     raise TimeoutError('Timeout while transmitting, waiting for text to be transmitted')
+                time.sleep(0.05)


### PR DESCRIPTION
When calling `send(msg)` with very slow digital modes like the THOR family, I noticed that CPU usage for the Python process was 100%, even though FlDigi itself was doing all of the modulation work, not the XML-RPC client bindings. This small PR adds 50ms `sleep()` to all of the polling tight loops. CPU usage for the Python process is now negligible while polling on my system, with local XML-RPC server.